### PR TITLE
Change the concave hull algorithm to be serial instead of recursive

### DIFF
--- a/esstoolkit/catchment_analyser/analysis_tools.py
+++ b/esstoolkit/catchment_analyser/analysis_tools.py
@@ -376,6 +376,13 @@ class ConcaveHull(object):
         return vertex_list
 
     def concave_hull(self, points_list, k):
+        hull, kk = self.concave_hull_serial(points_list, k)
+        while kk != k:
+            k = kk
+            hull, kk = self.concave_hull_serial(points_list, k)
+        return hull
+
+    def concave_hull_serial(self, points_list, k):
         """
         Calculates a valid concave hull polygon containing all given points. The algorithm searches for that
         point in the neighborhood of k nearest neighbors which maximizes the rotation angle in clockwise direction
@@ -389,7 +396,7 @@ class ConcaveHull(object):
         """
         # return an empty list if not enough points are given
         if k > len(points_list):
-            return None
+            return None, k
 
         # the number of nearest neighbors k must be greater than or equal to 3
         # kk = max(k, 3)
@@ -400,12 +407,12 @@ class ConcaveHull(object):
 
         # if point_set has less then 3 points no polygon can be created and an empty list will be returned
         if len(point_set) < 3:
-            return None
+            return None, k
 
         # if point_set has 3 points then these are already vertices of the hull. Append the first point to
         # close the hull polygon
         if len(point_set) == 3:
-            return self.add_point(point_set, point_set[0])
+            return self.add_point(point_set, point_set[0]), k
 
         # make sure that k neighbours can be found
         kk = min(kk, len(point_set))
@@ -463,7 +470,7 @@ class ConcaveHull(object):
                 # this tries to remove the potentially problematic recursion. might give less optimal results
                 # point_set = self.remove_point(point_set, current_point)
                 # continue
-                return self.concave_hull(points_list, kk + 1)
+                return None, kk + 1
 
             # the first point which complies with the requirements is added to the hull and gets the current point
             current_point = c_points[i]
@@ -489,7 +496,7 @@ class ConcaveHull(object):
 
         # since at least one point is out of the computed polygon, try again with a higher number of neighbors
         if all_inside is False:
-            return self.concave_hull(points_list, kk + 1)
+            return None, kk + 1
 
         # a valid hull has been constructed
-        return hull
+        return hull, k


### PR DESCRIPTION
There are two problems with this concave hull algorithm:
1) It has some situations where it freaks out, i.e. when there are consecutive points on the same border ([PR #3 attempts to fix that](https://github.com/pklampros/qgisSpaceSyntaxToolkit/pull/3))
2) When it freaks out, it might go into a recursive loop exhausting python's recursion limit and crashing QGIS. I don't seem to be able to capture the RecursionError which might be a problem with python, or QGIS.

The concave hull with k neighbours in the `processing` package is exactly the same algorithm and suffers from exactly the same problem. For example this can be observed by making a delimited-text file and running it from the QGIS interface (`Processing -> Toolbox -> Vector Geometry -> Concave hull (k-nearest neighbor)`) for example with these coordinates:
```
x,y
536843.99641527200583369,182639.99909931598813273
536950.00316584738902748,183024.99889427071320824
537037.42857955629006028,183040.00385779328644276
537060.97247206338215619,183044.0447337040968705
536719.99894137296359986,182628.00253329798579216
```

What this solution does is make the algorithm serial so that it doesn't crash the application, however the real solution would be to review the actual algorithm and solve the problems in there.